### PR TITLE
fix: switch build to CommonJS to fix broken ESM module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,13 @@
 {
   "name": "fixtures-ts",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Type-safe test fixture management with automatic dependency resolution",
-  "type": "module",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.js"
+      "require": "./dist/index.js"
     }
   },
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
+    "module": "commonjs",
     "lib": ["ES2022"],
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
     "outDir": "dist",


### PR DESCRIPTION
The compiled ESM output had extensionless imports that Node.js can't resolve, so we switched the build to CommonJS where extensionless imports work fine.